### PR TITLE
chore: deprecate and remove nomo.launchWebOn -> use nomo.installWebOn instead

### DIFF
--- a/demo-webon/public/nomo_manifest.json
+++ b/demo-webon/public/nomo_manifest.json
@@ -2,7 +2,7 @@
   "nomo_manifest_version": "1.2.0",
   "webon_id": "app.nomo.demowebon",
   "webon_name": "Dev WebOn",
-  "webon_version": "0.2.102",
+  "webon_version": "0.2.103",
   "min_nomo_version": "0.3.6",
   "dependencies": [
     "social:https://www.youtube.com/channel/UCsBtKDW5QAE4rKU5pmlFf-A"

--- a/demo-webon/src/app/multi-webons/multi_webon_demo.ts
+++ b/demo-webon/src/app/multi-webons/multi_webon_demo.ts
@@ -9,10 +9,12 @@ export async function launchAllWebOnsDemo() {
   if (!otherManifests.length) {
     throw Error("You need to install other WebOns to test this feature.");
   }
-  for (const manifest of otherManifests) {
-    await nomo.launchWebOn({
-      payload: "",
-      manifest,
+  const webOnsToLaunch = otherManifests.slice(0, 5);
+  for (const manifest of webOnsToLaunch) {
+    // nomo.installWebon launches a WebOn if already installed
+    await nomo.installWebOn({
+      deeplink: manifest.webon_url,
+      skipPermissionDialog: true,
     });
   }
 

--- a/nomo-webon-kit/dist/nomo_api.d.ts
+++ b/nomo-webon-kit/dist/nomo_api.d.ts
@@ -38,7 +38,6 @@ export declare const nomo: {
         removeItem: (key: string) => Promise<void>;
     };
     launchUrl: typeof multi.nomoLaunchUrl;
-    launchWebOn: typeof multi.nomoLaunchWebOn;
     launchUrlAsWebOn: typeof multi.nomoLaunchUrlAsWebOn;
     installWebOn: typeof multi.nomoInstallWebOn;
     installUrlAsWebOn: typeof multi.nomoInstallUrlAsWebOn;

--- a/nomo-webon-kit/dist/nomo_api.js
+++ b/nomo-webon-kit/dist/nomo_api.js
@@ -32,7 +32,6 @@ export const nomo = {
     disableFallbackWallet: web3.nomoDisableFallbackWallet,
     localStorage: multi.nomoLocalStorage,
     launchUrl: multi.nomoLaunchUrl,
-    launchWebOn: multi.nomoLaunchWebOn,
     launchUrlAsWebOn: multi.nomoLaunchUrlAsWebOn,
     installWebOn: multi.nomoInstallWebOn,
     installUrlAsWebOn: multi.nomoInstallUrlAsWebOn,

--- a/nomo-webon-kit/dist/nomo_multi_webons.d.ts
+++ b/nomo-webon-kit/dist/nomo_multi_webons.d.ts
@@ -129,17 +129,6 @@ export declare function nomoMigrateAndSelfDestroy(args: {
     new_deeplink: string;
 }): Promise<void>;
 /**
- * Opens another WebOn on top of the current WebOn.
- * If the WebOn is not yet running, the WebOn will be launched.
- * If the WebOn is not yet installed, an error is thrown.
- * A payload can be passed to the WebOn.
- * Afterwards, the user may navigate back to the current WebOn by pressing the back button.
- */
-export declare function nomoLaunchWebOn(args: {
-    payload: string;
-    manifest: NomoManifest;
-}): Promise<void>;
-/**
  * Passes a URL to the underlying platform for handling.
  * Typically, it will launch a system-browser or an in-app-webview.
  */
@@ -150,7 +139,6 @@ export declare function nomoLaunchUrl(args: {
 /**
  * Launches a URL as a WebOn without installing it.
  * Grants the permissions that are specified in the manifest.
- * If possible, please prefer "nomoLaunchUrl" or "nomoLaunchWebOn" over this function.
  *
  * Needs nomo.permission.INSTALL_WEBON.
  */

--- a/nomo-webon-kit/dist/nomo_multi_webons.js
+++ b/nomo-webon-kit/dist/nomo_multi_webons.js
@@ -118,16 +118,6 @@ export async function nomoMigrateAndSelfDestroy(args) {
     });
 }
 /**
- * Opens another WebOn on top of the current WebOn.
- * If the WebOn is not yet running, the WebOn will be launched.
- * If the WebOn is not yet installed, an error is thrown.
- * A payload can be passed to the WebOn.
- * Afterwards, the user may navigate back to the current WebOn by pressing the back button.
- */
-export async function nomoLaunchWebOn(args) {
-    return await invokeNomoFunction("nomoLaunchWebOn", args);
-}
-/**
  * Passes a URL to the underlying platform for handling.
  * Typically, it will launch a system-browser or an in-app-webview.
  */
@@ -141,7 +131,6 @@ export async function nomoLaunchUrl(args) {
 /**
  * Launches a URL as a WebOn without installing it.
  * Grants the permissions that are specified in the manifest.
- * If possible, please prefer "nomoLaunchUrl" or "nomoLaunchWebOn" over this function.
  *
  * Needs nomo.permission.INSTALL_WEBON.
  */

--- a/nomo-webon-kit/src/nomo_api.ts
+++ b/nomo-webon-kit/src/nomo_api.ts
@@ -34,7 +34,6 @@ export const nomo = {
 
   localStorage: multi.nomoLocalStorage,
   launchUrl: multi.nomoLaunchUrl,
-  launchWebOn: multi.nomoLaunchWebOn,
   launchUrlAsWebOn: multi.nomoLaunchUrlAsWebOn,
   installWebOn: multi.nomoInstallWebOn,
   installUrlAsWebOn: multi.nomoInstallUrlAsWebOn,

--- a/nomo-webon-kit/src/nomo_multi_webons.ts
+++ b/nomo-webon-kit/src/nomo_multi_webons.ts
@@ -196,20 +196,6 @@ export async function nomoMigrateAndSelfDestroy(args: {
 }
 
 /**
- * Opens another WebOn on top of the current WebOn.
- * If the WebOn is not yet running, the WebOn will be launched.
- * If the WebOn is not yet installed, an error is thrown.
- * A payload can be passed to the WebOn.
- * Afterwards, the user may navigate back to the current WebOn by pressing the back button.
- */
-export async function nomoLaunchWebOn(args: {
-  payload: string;
-  manifest: NomoManifest;
-}): Promise<void> {
-  return await invokeNomoFunction("nomoLaunchWebOn", args);
-}
-
-/**
  * Passes a URL to the underlying platform for handling.
  * Typically, it will launch a system-browser or an in-app-webview.
  */
@@ -231,7 +217,6 @@ export async function nomoLaunchUrl(args: {
 /**
  * Launches a URL as a WebOn without installing it.
  * Grants the permissions that are specified in the manifest.
- * If possible, please prefer "nomoLaunchUrl" or "nomoLaunchWebOn" over this function.
  *
  * Needs nomo.permission.INSTALL_WEBON.
  */


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the application version to 0.2.103.
	- Limited the launch of WebOns to a maximum of five, streamlining the demo experience.
	- Introduced a new installation method that bypasses the permission dialog for smoother operation.

- **Bug Fixes**
	- Removed outdated methods to enhance functionality and ensure a more efficient interface.

- **Refactor**
	- Simplified the control flow for launching WebOns, improving overall performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->