### PR TITLE
fix: nomoSendERC20 workaround for nomo.sendAssets

### DIFF
--- a/demo-webon/public/nomo_manifest.json
+++ b/demo-webon/public/nomo_manifest.json
@@ -2,7 +2,7 @@
   "nomo_manifest_version": "1.2.0",
   "webon_id": "app.nomo.demowebon",
   "webon_name": "Dev WebOn",
-  "webon_version": "0.2.109",
+  "webon_version": "0.2.110",
   "min_nomo_version": "0.3.6",
   "dependencies": [
     "social:https://www.youtube.com/channel/UCsBtKDW5QAE4rKU5pmlFf-A"

--- a/demo-webon/public/nomo_manifest.json
+++ b/demo-webon/public/nomo_manifest.json
@@ -2,7 +2,7 @@
   "nomo_manifest_version": "1.2.0",
   "webon_id": "app.nomo.demowebon",
   "webon_name": "Dev WebOn",
-  "webon_version": "0.2.110",
+  "webon_version": "0.2.111",
   "min_nomo_version": "0.3.6",
   "dependencies": [
     "social:https://www.youtube.com/channel/UCsBtKDW5QAE4rKU5pmlFf-A"

--- a/demo-webon/src/api-tests/tests/tc-send-assets.ts
+++ b/demo-webon/src/api-tests/tests/tc-send-assets.ts
@@ -44,7 +44,7 @@ class SendAssetsBEP20USDT extends NomoTest {
   constructor() {
     super({
       name: "Send Assets: BEP20-USDT",
-      description: "Do not send, click the back-button.",
+      description: "Send USDT to yourself.",
     });
   }
 
@@ -59,6 +59,29 @@ class SendAssetsBEP20USDT extends NomoTest {
       asset,
       targetAddress,
       amount: "100000", // in wei
+    });
+  }
+}
+
+class SendAssetsBEP20BUSD extends NomoTest {
+  constructor() {
+    super({
+      name: "Send Assets: BEP20-BUSD",
+      description: "Send BUSD to yourself.",
+    });
+  }
+
+  async run() {
+    const targetAddress = await nomo.getEvmAddress();
+    const asset: NomoAssetSelector = {
+      symbol: "BUSD",
+      contractAddress: "0xe9e7CEA3DedcA5984780Bafc599bD69ADd087D56",
+      network: "binance-smart-chain",
+    };
+    await nomo.sendAssets({
+      asset,
+      targetAddress,
+      amount: "10000", // in wei
     });
   }
 }
@@ -126,6 +149,7 @@ class GetBalanceUUID extends NomoTest {
 export const sendAssetsManualTests: Array<NomoTest> = [
   new SendAssetsEthereum(),
   new SendAssetsBEP20USDT(),
+  new SendAssetsBEP20BUSD(),
 ];
 
 export const sendAssetsUnitTests: Array<NomoTest> = [

--- a/nomo-webon-kit/dist/nomo_api.d.ts
+++ b/nomo-webon-kit/dist/nomo_api.d.ts
@@ -11,6 +11,7 @@ import * as auth from "./nomo_auth";
 export declare const nomo: {
     signEvmTransaction: typeof web3.nomoSignEvmTransaction;
     sendAssets: typeof web3.nomoSendAssets;
+    sendERC20: typeof web3.nomoSendERC20;
     selectAssets: typeof web3.nomoSelectAssets;
     selectAssetFromDialog: typeof web3.nomoSelectAssetFromDialog;
     getEvmAddress: typeof web3.nomoGetEvmAddress;

--- a/nomo-webon-kit/dist/nomo_api.js
+++ b/nomo-webon-kit/dist/nomo_api.js
@@ -11,6 +11,7 @@ import * as auth from "./nomo_auth";
 export const nomo = {
     signEvmTransaction: web3.nomoSignEvmTransaction,
     sendAssets: web3.nomoSendAssets,
+    sendERC20: web3.nomoSendERC20,
     selectAssets: web3.nomoSelectAssets,
     selectAssetFromDialog: web3.nomoSelectAssetFromDialog,
     getEvmAddress: web3.nomoGetEvmAddress,

--- a/nomo-webon-kit/dist/nomo_web3.d.ts
+++ b/nomo-webon-kit/dist/nomo_web3.d.ts
@@ -1,4 +1,4 @@
-export type NomoEvmNetwork = "zeniq-smart-chain" | "ethereum" | "binance-smart-chain";
+export type NomoEvmNetwork = "zeniq-smart-chain" | "ethereum" | "polygon" | "binance-smart-chain";
 export type NomoNetwork = NomoEvmNetwork | "bitcoin" | "zeniq" | "litecoin" | "bitcoincash";
 export interface NomoAssetSelector {
     /**
@@ -55,6 +55,23 @@ export declare function nomoSendAssets(args: {
     asset?: NomoAssetSelector;
     targetAddress?: string;
     amount?: string;
+}): Promise<{
+    hash: string;
+    intent: {
+        recipient: string;
+        amount: string;
+        token: string;
+    };
+}>;
+/**
+ * Sends an ERC20-token to a target address.
+ * For EVM-based tokens, this is a third alternative to "ethersjs-nomo-webons" and "nomoSendAssets".
+ */
+export declare function nomoSendERC20(args: {
+    contractAddress: string;
+    targetAddress: string;
+    amount: string;
+    network: NomoEvmNetwork;
 }): Promise<{
     hash: string;
     intent: {

--- a/nomo-webon-kit/dist/nomo_web3.js
+++ b/nomo-webon-kit/dist/nomo_web3.js
@@ -111,11 +111,11 @@ export async function nomoSendERC20(args) {
         url: rpcUrl,
     });
     const txFields = [
-        nonce,
-        gasPrice,
+        nonce.result,
+        gasPrice.result,
         gasLimit,
         args.contractAddress,
-        "0x0",
+        "0x",
         data,
         nomoGetChainId(args.network),
         "0x",

--- a/nomo-webon-kit/dist/nomo_web3.js
+++ b/nomo-webon-kit/dist/nomo_web3.js
@@ -1,6 +1,7 @@
 import { invokeNomoFunction, invokeNomoFunctionCached, isFallbackModeActive, } from "./dart_interface";
 import { nomoAuthFetch } from "./nomo_auth";
 import { nomoGetInstalledWebOns, nomoInstallWebOn } from "./nomo_multi_webons";
+import { hasMinimumNomoVersion } from "./nomo_platform";
 import { nomoJsonRPC, rlpEncodeList, sleep } from "./util";
 /**
  * Prevents functions like "nomoGetEvmAddress" from falling back to browser extensions like MetaMask.
@@ -48,12 +49,14 @@ export async function nomoSendAssets(args) {
         args.amount &&
         args.asset?.contractAddress &&
         args.asset?.network) {
-        return await nomoSendERC20({
-            targetAddress: args.targetAddress,
-            amount: args.amount,
-            contractAddress: args.asset?.contractAddress,
-            network: args.asset?.network,
-        });
+        if ((await hasMinimumNomoVersion({ minVersion: "0.6.4" })).minVersionFulfilled) {
+            return await nomoSendERC20({
+                targetAddress: args.targetAddress,
+                amount: args.amount,
+                contractAddress: args.asset?.contractAddress,
+                network: args.asset?.network,
+            });
+        }
     }
     return await invokeNomoFunction("nomoSendAssets", args);
 }

--- a/nomo-webon-kit/dist/nomo_web3.js
+++ b/nomo-webon-kit/dist/nomo_web3.js
@@ -95,8 +95,8 @@ export async function nomoSendERC20(args) {
         return value.toString(16).padStart(padding * 2, "0");
     }
     const transferMethodId = "a9059cbb"; // First 4 bytes of keccak256("transfer(address,uint256)")
-    const targetAddressEncoded = toHex(BigInt(args.targetAddress), 20); // Address is 20 bytes
-    const amountEncoded = toHex(BigInt(args.amount)); // Amount is 32 bytes
+    const targetAddressEncoded = toHex(BigInt(args.targetAddress), 32);
+    const amountEncoded = toHex(BigInt(args.amount), 32);
     const data = "0x" + transferMethodId + targetAddressEncoded + amountEncoded;
     const gasLimit = 75000;
     const rpcUrl = nomoGetFreeRPCUrl(args.network);

--- a/nomo-webon-kit/dist/nomo_web3.js
+++ b/nomo-webon-kit/dist/nomo_web3.js
@@ -1,7 +1,7 @@
 import { invokeNomoFunction, invokeNomoFunctionCached, isFallbackModeActive, } from "./dart_interface";
 import { nomoAuthFetch } from "./nomo_auth";
 import { nomoGetInstalledWebOns, nomoInstallWebOn } from "./nomo_multi_webons";
-import { sleep } from "./util";
+import { nomoJsonRPC, rlpEncodeList, sleep } from "./util";
 /**
  * Prevents functions like "nomoGetEvmAddress" from falling back to browser extensions like MetaMask.
  */
@@ -43,8 +43,98 @@ export async function nomoSignEvmTransaction(args) {
  * Needs nomo.permission.SEND_ASSETS.
  */
 export async function nomoSendAssets(args) {
-    const legacyArgs = { ...args, assetSymbol: args.asset?.symbol ?? null };
-    return await invokeNomoFunction("nomoSendAssets", legacyArgs);
+    if (args.asset?.network !== "ethereum" &&
+        args.targetAddress?.startsWith("0x") &&
+        args.amount &&
+        args.asset?.contractAddress &&
+        args.asset?.network) {
+        return await nomoSendERC20({
+            targetAddress: args.targetAddress,
+            amount: args.amount,
+            contractAddress: args.asset?.contractAddress,
+            network: args.asset?.network,
+        });
+    }
+    return await invokeNomoFunction("nomoSendAssets", args);
+}
+function nomoGetChainId(network) {
+    switch (network) {
+        case "ethereum":
+            return 1;
+        case "polygon":
+            return 137;
+        case "binance-smart-chain":
+            return 56;
+        case "zeniq-smart-chain":
+            return 383414847825;
+        default:
+            throw Error("Unknown chainID for network: " + network);
+    }
+}
+function nomoGetFreeRPCUrl(network) {
+    switch (network) {
+        case "binance-smart-chain":
+            return "https://bsc-dataseed.binance.org";
+        case "zeniq-smart-chain":
+            return "https://api.zeniq.network";
+        case "polygon":
+            return "https://polygon.llamarpc.com";
+        default:
+            throw Error("No free open-source RPC-URL for network: " + network);
+    }
+}
+/**
+ * Sends an ERC20-token to a target address.
+ * For EVM-based tokens, this is a third alternative to "ethersjs-nomo-webons" and "nomoSendAssets".
+ */
+export async function nomoSendERC20(args) {
+    function toHex(value, padding = 32) {
+        return value.toString(16).padStart(padding * 2, "0");
+    }
+    const transferMethodId = "a9059cbb"; // First 4 bytes of keccak256("transfer(address,uint256)")
+    const targetAddressEncoded = toHex(BigInt(args.targetAddress), 20); // Address is 20 bytes
+    const amountEncoded = toHex(BigInt(args.amount)); // Amount is 32 bytes
+    const data = "0x" + transferMethodId + targetAddressEncoded + amountEncoded;
+    const gasLimit = 75000;
+    const rpcUrl = nomoGetFreeRPCUrl(args.network);
+    const nonce = await nomoJsonRPC({
+        method: "eth_getTransactionCount",
+        params: [await nomoGetEvmAddress(), "latest"],
+        url: rpcUrl,
+    });
+    const gasPrice = await nomoJsonRPC({
+        method: "eth_gasPrice",
+        params: [],
+        url: rpcUrl,
+    });
+    const txFields = [
+        nonce,
+        gasPrice,
+        gasLimit,
+        args.contractAddress,
+        "0x0",
+        data,
+        nomoGetChainId(args.network),
+        "0x",
+        "0x", // Empty r (placeholder for signing)
+    ];
+    const rlpEncodedTx = rlpEncodeList(txFields);
+    const { txHex } = await nomoSignEvmTransaction({
+        messageHex: rlpEncodedTx,
+    });
+    const hash = await nomoJsonRPC({
+        method: "eth_sendRawTransaction",
+        params: [txHex],
+        url: rpcUrl,
+    });
+    return {
+        hash,
+        intent: {
+            recipient: args.targetAddress,
+            amount: args.amount,
+            token: args.contractAddress,
+        },
+    };
 }
 /**
  * Checks whether an asset is available in the Nomo Wallet, and whether the asset is visible.
@@ -187,8 +277,7 @@ export async function nomoGetWalletAddresses() {
  * May throw an error if no icons can be found.
  */
 export async function nomoGetAssetIcon(args) {
-    const legacyArgs = { ...args, assetSymbol: args.symbol };
-    return await invokeNomoFunction("nomoGetAssetIcon", legacyArgs);
+    return await invokeNomoFunction("nomoGetAssetIcon", args);
 }
 /**
  * Returns an asset price.

--- a/nomo-webon-kit/dist/util.d.ts
+++ b/nomo-webon-kit/dist/util.d.ts
@@ -24,6 +24,7 @@ export declare function profile(fn: () => Promise<void>, options: {
     name: string;
 }): Promise<void>;
 export declare function isHexString(str: string): boolean;
+export declare function rlpEncodeElement(input: any): string;
 export declare function rlpEncodeList(elements: any[]): string;
 export declare function nomoJsonRPC(args: {
     method: string;

--- a/nomo-webon-kit/dist/util.d.ts
+++ b/nomo-webon-kit/dist/util.d.ts
@@ -24,3 +24,9 @@ export declare function profile(fn: () => Promise<void>, options: {
     name: string;
 }): Promise<void>;
 export declare function isHexString(str: string): boolean;
+export declare function rlpEncodeList(elements: any[]): string;
+export declare function nomoJsonRPC(args: {
+    method: string;
+    params: any[];
+    url: string;
+}): Promise<any>;

--- a/nomo-webon-kit/dist/util.js
+++ b/nomo-webon-kit/dist/util.js
@@ -109,3 +109,47 @@ export async function profile(fn, options) {
 export function isHexString(str) {
     return /^[0-9a-fA-F]+$/.test(str);
 }
+function encodeLength(len, offset) {
+    if (len < 56)
+        return (len + offset).toString(16).padStart(2, "0");
+    const hexLength = len.toString(16);
+    return (hexLength.length / 2 + offset + 55).toString(16) + hexLength;
+}
+function rlpEncode(input) {
+    if (typeof input === "string" && input.startsWith("0x")) {
+        input = input.slice(2);
+    }
+    if (typeof input === "number" || typeof input === "bigint") {
+        input = input.toString(16);
+    }
+    if (input.length === 0 || input === "00") {
+        return "80"; // Empty value
+    }
+    if (input.length % 2 !== 0) {
+        input = "0" + input; // Ensure even-length hex
+    }
+    const length = input.length / 2;
+    return length < 56
+        ? (128 + length).toString(16) + input
+        : encodeLength(length, 128) + input;
+}
+export function rlpEncodeList(elements) {
+    const encodedElements = elements.map(rlpEncode).join("");
+    const length = encodedElements.length / 2;
+    return encodeLength(length, 192) + encodedElements;
+}
+export async function nomoJsonRPC(args) {
+    const res = await fetch(args.url, {
+        method: "POST",
+        headers: {
+            "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+            jsonrpc: "2.0",
+            id: 1,
+            method: args.method,
+            params: args.params,
+        }),
+    });
+    return await res.json();
+}

--- a/nomo-webon-kit/dist/util.js
+++ b/nomo-webon-kit/dist/util.js
@@ -110,33 +110,40 @@ export function isHexString(str) {
     return /^[0-9a-fA-F]+$/.test(str);
 }
 function encodeLength(len, offset) {
-    if (len < 56)
+    if (len < 56) {
         return (len + offset).toString(16).padStart(2, "0");
+    }
     const hexLength = len.toString(16);
     return (hexLength.length / 2 + offset + 55).toString(16) + hexLength;
 }
-function rlpEncode(input) {
+export function rlpEncodeElement(input) {
     if (typeof input === "string" && input.startsWith("0x")) {
-        input = input.slice(2);
+        input = input.slice(2); // Remove '0x' if present
     }
     if (typeof input === "number" || typeof input === "bigint") {
-        input = input.toString(16);
+        input = input.toString(16); // Convert to hex string
     }
-    if (input.length === 0 || input === "00") {
-        return "80"; // Empty value
+    if (!input || input === "0" || input === "") {
+        return "80"; // Encodes empty or zero as 0x80
     }
     if (input.length % 2 !== 0) {
         input = "0" + input; // Ensure even-length hex
     }
     const length = input.length / 2;
-    return length < 56
-        ? (128 + length).toString(16) + input
-        : encodeLength(length, 128) + input;
+    if (length < 56) {
+        return (128 + length).toString(16) + input;
+    }
+    else {
+        return encodeLength(length, 128) + input;
+    }
 }
 export function rlpEncodeList(elements) {
-    const encodedElements = elements.map(rlpEncode).join("");
-    const length = encodedElements.length / 2;
-    return encodeLength(length, 192) + encodedElements;
+    const encoded = elements.map(rlpEncodeElement).join(""); // Encode each element
+    const totalLength = encoded.length / 2; // Total byte length of the concatenated elements
+    if (totalLength < 56)
+        return (192 + totalLength).toString(16) + encoded; // Short form
+    const lenHex = totalLength.toString(16); // Length in hex
+    return (247 + lenHex.length / 2).toString(16) + lenHex + encoded; // Long form
 }
 export async function nomoJsonRPC(args) {
     const res = await fetch(args.url, {

--- a/nomo-webon-kit/src/nomo_api.ts
+++ b/nomo-webon-kit/src/nomo_api.ts
@@ -12,6 +12,7 @@ import * as auth from "./nomo_auth";
 export const nomo = {
   signEvmTransaction: web3.nomoSignEvmTransaction,
   sendAssets: web3.nomoSendAssets,
+  sendERC20: web3.nomoSendERC20,
   selectAssets: web3.nomoSelectAssets,
   selectAssetFromDialog: web3.nomoSelectAssetFromDialog,
   getEvmAddress: web3.nomoGetEvmAddress,

--- a/nomo-webon-kit/src/nomo_web3.ts
+++ b/nomo-webon-kit/src/nomo_web3.ts
@@ -5,6 +5,7 @@ import {
 } from "./dart_interface";
 import { nomoAuthFetch } from "./nomo_auth";
 import { nomoGetInstalledWebOns, nomoInstallWebOn } from "./nomo_multi_webons";
+import { hasMinimumNomoVersion } from "./nomo_platform";
 import { nomoJsonRPC, rlpEncodeList, sleep } from "./util";
 
 export type NomoEvmNetwork =
@@ -111,12 +112,16 @@ export async function nomoSendAssets(args: {
     args.asset?.contractAddress &&
     args.asset?.network
   ) {
-    return await nomoSendERC20({
-      targetAddress: args.targetAddress,
-      amount: args.amount,
-      contractAddress: args.asset?.contractAddress,
-      network: args.asset?.network as NomoEvmNetwork,
-    });
+    if (
+      (await hasMinimumNomoVersion({ minVersion: "0.6.4" })).minVersionFulfilled
+    ) {
+      return await nomoSendERC20({
+        targetAddress: args.targetAddress,
+        amount: args.amount,
+        contractAddress: args.asset?.contractAddress,
+        network: args.asset?.network as NomoEvmNetwork,
+      });
+    }
   }
   return await invokeNomoFunction("nomoSendAssets", args);
 }

--- a/nomo-webon-kit/src/nomo_web3.ts
+++ b/nomo-webon-kit/src/nomo_web3.ts
@@ -5,11 +5,12 @@ import {
 } from "./dart_interface";
 import { nomoAuthFetch } from "./nomo_auth";
 import { nomoGetInstalledWebOns, nomoInstallWebOn } from "./nomo_multi_webons";
-import { sleep } from "./util";
+import { nomoJsonRPC, rlpEncodeList, sleep } from "./util";
 
 export type NomoEvmNetwork =
   | "zeniq-smart-chain"
   | "ethereum"
+  | "polygon"
   | "binance-smart-chain";
 export type NomoNetwork =
   | NomoEvmNetwork
@@ -103,8 +104,111 @@ export async function nomoSendAssets(args: {
   hash: string;
   intent: { recipient: string; amount: string; token: string };
 }> {
-  const legacyArgs = { ...args, assetSymbol: args.asset?.symbol ?? null };
-  return await invokeNomoFunction("nomoSendAssets", legacyArgs);
+  if (
+    args.asset?.network !== "ethereum" &&
+    args.targetAddress?.startsWith("0x") &&
+    args.amount &&
+    args.asset?.contractAddress &&
+    args.asset?.network
+  ) {
+    return await nomoSendERC20({
+      targetAddress: args.targetAddress,
+      amount: args.amount,
+      contractAddress: args.asset?.contractAddress,
+      network: args.asset?.network as NomoEvmNetwork,
+    });
+  }
+  return await invokeNomoFunction("nomoSendAssets", args);
+}
+
+function nomoGetChainId(network: NomoEvmNetwork): number {
+  switch (network) {
+    case "ethereum":
+      return 1;
+    case "polygon":
+      return 137;
+    case "binance-smart-chain":
+      return 56;
+    case "zeniq-smart-chain":
+      return 383414847825;
+    default:
+      throw Error("Unknown chainID for network: " + network);
+  }
+}
+
+function nomoGetFreeRPCUrl(network: NomoEvmNetwork): string {
+  switch (network) {
+    case "binance-smart-chain":
+      return "https://bsc-dataseed.binance.org";
+    case "zeniq-smart-chain":
+      return "https://api.zeniq.network";
+    case "polygon":
+      return "https://polygon.llamarpc.com";
+    default:
+      throw Error("No free open-source RPC-URL for network: " + network);
+  }
+}
+
+/**
+ * Sends an ERC20-token to a target address.
+ * For EVM-based tokens, this is a third alternative to "ethersjs-nomo-webons" and "nomoSendAssets".
+ */
+export async function nomoSendERC20(args: {
+  contractAddress: string;
+  targetAddress: string;
+  amount: string;
+  network: NomoEvmNetwork;
+}): Promise<{
+  hash: string;
+  intent: { recipient: string; amount: string; token: string };
+}> {
+  function toHex(value: bigint, padding = 32) {
+    return value.toString(16).padStart(padding * 2, "0");
+  }
+  const transferMethodId = "a9059cbb"; // First 4 bytes of keccak256("transfer(address,uint256)")
+  const targetAddressEncoded = toHex(BigInt(args.targetAddress), 20); // Address is 20 bytes
+  const amountEncoded = toHex(BigInt(args.amount)); // Amount is 32 bytes
+  const data = "0x" + transferMethodId + targetAddressEncoded + amountEncoded;
+  const gasLimit = 75000;
+  const rpcUrl = nomoGetFreeRPCUrl(args.network);
+  const nonce = await nomoJsonRPC({
+    method: "eth_getTransactionCount",
+    params: [await nomoGetEvmAddress(), "latest"],
+    url: rpcUrl,
+  });
+  const gasPrice = await nomoJsonRPC({
+    method: "eth_gasPrice",
+    params: [],
+    url: rpcUrl,
+  });
+  const txFields = [
+    nonce,
+    gasPrice,
+    gasLimit,
+    args.contractAddress, // To
+    "0x0", // Value (native value is zero for ERC20)
+    data,
+    nomoGetChainId(args.network),
+    "0x", // Empty v (placeholder for signing)
+    "0x", // Empty r (placeholder for signing)
+  ];
+  const rlpEncodedTx = rlpEncodeList(txFields);
+  const { txHex } = await nomoSignEvmTransaction({
+    messageHex: rlpEncodedTx,
+  });
+  const hash = await nomoJsonRPC({
+    method: "eth_sendRawTransaction",
+    params: [txHex],
+    url: rpcUrl,
+  });
+  return {
+    hash,
+    intent: {
+      recipient: args.targetAddress,
+      amount: args.amount,
+      token: args.contractAddress,
+    },
+  };
 }
 
 /**
@@ -279,8 +383,7 @@ export async function nomoGetAssetIcon(args: NomoAssetSelector): Promise<{
   symbol: string;
   name: string;
 }> {
-  const legacyArgs = { ...args, assetSymbol: args.symbol };
-  return await invokeNomoFunction("nomoGetAssetIcon", legacyArgs);
+  return await invokeNomoFunction("nomoGetAssetIcon", args);
 }
 
 /**

--- a/nomo-webon-kit/src/nomo_web3.ts
+++ b/nomo-webon-kit/src/nomo_web3.ts
@@ -187,11 +187,11 @@ export async function nomoSendERC20(args: {
     url: rpcUrl,
   });
   const txFields = [
-    nonce,
-    gasPrice,
+    nonce.result,
+    gasPrice.result,
     gasLimit,
     args.contractAddress, // To
-    "0x0", // Value (native value is zero for ERC20)
+    "0x", // Value (native value is zero for ERC20)
     data,
     nomoGetChainId(args.network),
     "0x", // Empty v (placeholder for signing)

--- a/nomo-webon-kit/src/nomo_web3.ts
+++ b/nomo-webon-kit/src/nomo_web3.ts
@@ -171,8 +171,8 @@ export async function nomoSendERC20(args: {
     return value.toString(16).padStart(padding * 2, "0");
   }
   const transferMethodId = "a9059cbb"; // First 4 bytes of keccak256("transfer(address,uint256)")
-  const targetAddressEncoded = toHex(BigInt(args.targetAddress), 20); // Address is 20 bytes
-  const amountEncoded = toHex(BigInt(args.amount)); // Amount is 32 bytes
+  const targetAddressEncoded = toHex(BigInt(args.targetAddress), 32);
+  const amountEncoded = toHex(BigInt(args.amount), 32);
   const data = "0x" + transferMethodId + targetAddressEncoded + amountEncoded;
   const gasLimit = 75000;
   const rpcUrl = nomoGetFreeRPCUrl(args.network);

--- a/nomo-webon-kit/src/util.ts
+++ b/nomo-webon-kit/src/util.ts
@@ -127,34 +127,40 @@ export function isHexString(str: string) {
 }
 
 function encodeLength(len: number, offset: number) {
-  if (len < 56) return (len + offset).toString(16).padStart(2, "0");
+  if (len < 56) {
+    return (len + offset).toString(16).padStart(2, "0");
+  }
   const hexLength = len.toString(16);
   return (hexLength.length / 2 + offset + 55).toString(16) + hexLength;
 }
 
-function rlpEncode(input: any) {
+export function rlpEncodeElement(input: any) {
   if (typeof input === "string" && input.startsWith("0x")) {
-    input = input.slice(2);
+    input = input.slice(2); // Remove '0x' if present
   }
   if (typeof input === "number" || typeof input === "bigint") {
-    input = input.toString(16);
+    input = input.toString(16); // Convert to hex string
   }
-  if (input.length === 0 || input === "00") {
-    return "80"; // Empty value
+  if (!input || input === "0" || input === "") {
+    return "80"; // Encodes empty or zero as 0x80
   }
   if (input.length % 2 !== 0) {
     input = "0" + input; // Ensure even-length hex
   }
   const length = input.length / 2;
-  return length < 56
-    ? (128 + length).toString(16) + input
-    : encodeLength(length, 128) + input;
+  if (length < 56) {
+    return (128 + length).toString(16) + input;
+  } else {
+    return encodeLength(length, 128) + input;
+  }
 }
 
 export function rlpEncodeList(elements: any[]) {
-  const encodedElements = elements.map(rlpEncode).join("");
-  const length = encodedElements.length / 2;
-  return encodeLength(length, 192) + encodedElements;
+  const encoded = elements.map(rlpEncodeElement).join(""); // Encode each element
+  const totalLength = encoded.length / 2; // Total byte length of the concatenated elements
+  if (totalLength < 56) return (192 + totalLength).toString(16) + encoded; // Short form
+  const lenHex = totalLength.toString(16); // Length in hex
+  return (247 + lenHex.length / 2).toString(16) + lenHex + encoded; // Long form
 }
 
 export async function nomoJsonRPC(args: {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced the ability to send ERC20 tokens through the new `sendERC20` method.
	- Added support for the "polygon" EVM network.
	- Enhanced asset management with updated `nomoSendAssets` function to handle ERC20 transactions.
	- New functions for retrieving chain IDs and free RPC URLs.
	- Added `nomoJsonRPC` for performing JSON-RPC calls.
	- Introduced a new test case for sending BUSD assets.

- **Improvements**
	- Simplified asset icon retrieval process.
	- Enhanced encoding functions for better data handling.
	- Updated test case descriptions to reflect active sending scenarios.

- **Version Update**
	- Incremented `webon_version` from `0.2.109` to `0.2.111`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->