### PR TITLE
nomo.close API

### DIFF
--- a/demo-webon/public/nomo_manifest.json
+++ b/demo-webon/public/nomo_manifest.json
@@ -2,7 +2,7 @@
   "nomo_manifest_version": "1.2.0",
   "webon_id": "app.nomo.demowebon",
   "webon_name": "Dev WebOn",
-  "webon_version": "0.2.134",
+  "webon_version": "0.2.135",
   "min_nomo_version": "0.3.6",
   "dependencies": [
     "social:https://www.youtube.com/channel/UCsBtKDW5QAE4rKU5pmlFf-A"

--- a/demo-webon/src/api-tests/tests/tc-nomo-core.ts
+++ b/demo-webon/src/api-tests/tests/tc-nomo-core.ts
@@ -1,31 +1,6 @@
 import { nomo } from "nomo-webon-kit";
 import { NomoTest } from "../test-kit/nomo-test";
 
-class CheckIfRealNomoTest extends NomoTest {
-  constructor() {
-    super({
-      name: "Anti-spam",
-      description:
-        "Check if a request comes from a real Nomo-wallet and not from some automated script.",
-    });
-  }
-
-  async run() {
-    const evmAddress = await nomo.getEvmAddress();
-    const res = await nomo.authHttp({
-      url: "https://nomoplus.com/api/has-nomo",
-      method: "POST",
-      body: { eth_addr: evmAddress },
-    });
-    const resJson = JSON.parse(res.response);
-    if (!resJson.has_nomo) {
-      throw new Error(
-        "has_nomo is not true. Is this a real Nomo wallet? " + res.response
-      );
-    }
-  }
-}
-
 class EvmChecksumTest extends NomoTest {
   constructor() {
     super({
@@ -51,7 +26,25 @@ class EvmChecksumTest extends NomoTest {
   }
 }
 
+class NomoCloseTest extends NomoTest {
+  constructor() {
+    super({
+      name: "nomo.close()",
+      description: "Closes the current WebOn and then launches a deeplink.",
+    });
+  }
+
+  async run() {
+    const manifest = await nomo.getManifest();
+    const url = manifest.webon_url;
+    const deeplink = url
+      .replace("https://", "https://nomo.app/webon/")
+      .replace("http://", "http://nomo.app/webon/");
+    await nomo.close({ deeplink }); // re-open the current WebOn after closing it
+  }
+}
+
 export const nomoCoreTests: Array<NomoTest> = [
-  new CheckIfRealNomoTest(),
+  new NomoCloseTest(),
   new EvmChecksumTest(),
 ];

--- a/nomo-webon-kit/dist/nomo_api.d.ts
+++ b/nomo-webon-kit/dist/nomo_api.d.ts
@@ -71,6 +71,7 @@ export declare const nomo: {
     share: typeof platform.nomoShare;
     getClipboard: typeof platform.nomoGetClipboard;
     setClipboard: typeof platform.nomoSetClipboard;
+    close: typeof platform.nomoClose;
     injectNomoCSSVariables: typeof theming.injectNomoCSSVariables;
     switchNomoTheme: typeof theming.switchNomoTheme;
     getCurrentNomoTheme: typeof theming.getCurrentNomoTheme;

--- a/nomo-webon-kit/dist/nomo_api.js
+++ b/nomo-webon-kit/dist/nomo_api.js
@@ -65,6 +65,7 @@ export const nomo = {
     share: platform.nomoShare,
     getClipboard: platform.nomoGetClipboard,
     setClipboard: platform.nomoSetClipboard,
+    close: platform.nomoClose,
     injectNomoCSSVariables: theming.injectNomoCSSVariables,
     switchNomoTheme: theming.switchNomoTheme,
     getCurrentNomoTheme: theming.getCurrentNomoTheme,

--- a/nomo-webon-kit/dist/nomo_platform.d.ts
+++ b/nomo-webon-kit/dist/nomo_platform.d.ts
@@ -97,3 +97,10 @@ export declare function nomoShare(args: {
     text?: string;
     subject?: string;
 }): Promise<void>;
+/**
+ * Closes the current WebOn.
+ * Afterwards, it will launch a deeplink if provided.
+ */
+export declare function nomoClose(args: {
+    deeplink: string | null;
+}): Promise<void>;

--- a/nomo-webon-kit/dist/nomo_platform.js
+++ b/nomo-webon-kit/dist/nomo_platform.js
@@ -154,3 +154,10 @@ export async function nomoShare(args) {
         navigator.share({ text: args.text });
     }
 }
+/**
+ * Closes the current WebOn.
+ * Afterwards, it will launch a deeplink if provided.
+ */
+export async function nomoClose(args) {
+    await invokeNomoFunction("nomoClose", args);
+}

--- a/nomo-webon-kit/src/nomo_api.ts
+++ b/nomo-webon-kit/src/nomo_api.ts
@@ -69,6 +69,7 @@ export const nomo = {
   share: platform.nomoShare,
   getClipboard: platform.nomoGetClipboard,
   setClipboard: platform.nomoSetClipboard,
+  close: platform.nomoClose,
 
   injectNomoCSSVariables: theming.injectNomoCSSVariables,
   switchNomoTheme: theming.switchNomoTheme,

--- a/nomo-webon-kit/src/nomo_platform.ts
+++ b/nomo-webon-kit/src/nomo_platform.ts
@@ -197,3 +197,13 @@ export async function nomoShare(args: {
     navigator.share({ text: args.text });
   }
 }
+
+/**
+ * Closes the current WebOn.
+ * Afterwards, it will launch a deeplink if provided.
+ */
+export async function nomoClose(args: {
+  deeplink: string | null;
+}): Promise<void> {
+  await invokeNomoFunction("nomoClose", args);
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the WebOn version to 0.2.135.
	- Introduced a new test for closing WebOn and launching a deeplink.
	- Added a method to the `nomo` object for closing operations.
	- Implemented a new asynchronous function to close WebOn and handle deeplinks.

- **Bug Fixes**
	- Removed an outdated test class to streamline testing processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->