### PR TITLE
feat: allow to specify a launchMode for nomo.close()-deeplinks

### DIFF
--- a/demo-webon/public/nomo_manifest.json
+++ b/demo-webon/public/nomo_manifest.json
@@ -2,7 +2,7 @@
   "nomo_manifest_version": "1.2.0",
   "webon_id": "app.nomo.demowebon",
   "webon_name": "Dev WebOn",
-  "webon_version": "0.2.138",
+  "webon_version": "0.2.139",
   "min_nomo_version": "0.3.6",
   "dependencies": [
     "social:https://www.youtube.com/channel/UCsBtKDW5QAE4rKU5pmlFf-A"

--- a/demo-webon/src/api-tests/tests/tc-nomo-core.ts
+++ b/demo-webon/src/api-tests/tests/tc-nomo-core.ts
@@ -40,7 +40,7 @@ class NomoCloseTest extends NomoTest {
     const deeplink = url
       .replace("https://", "https://nomo.app/webon/")
       .replace("http://", "http://nomo.app/webon/");
-    await nomo.close({ deeplink }); // re-open the current WebOn after closing it
+    await nomo.close({ deeplink, launchMode: null }); // re-open the current WebOn after closing it
   }
 }
 

--- a/nomo-webon-kit/dist/nomo_platform.d.ts
+++ b/nomo-webon-kit/dist/nomo_platform.d.ts
@@ -100,7 +100,9 @@ export declare function nomoShare(args: {
 /**
  * Closes the current WebOn.
  * Afterwards, it will launch a deeplink if provided.
+ * A launchMode can be specified to control how the deeplink is opened.
  */
 export declare function nomoClose(args: {
     deeplink: string | null;
+    launchMode: null | "platformDefault" | "inAppWebView" | "externalApplication" | "externalNonBrowserApplication";
 }): Promise<void>;

--- a/nomo-webon-kit/dist/nomo_platform.js
+++ b/nomo-webon-kit/dist/nomo_platform.js
@@ -157,6 +157,7 @@ export async function nomoShare(args) {
 /**
  * Closes the current WebOn.
  * Afterwards, it will launch a deeplink if provided.
+ * A launchMode can be specified to control how the deeplink is opened.
  */
 export async function nomoClose(args) {
     await invokeNomoFunction("nomoClose", args);

--- a/nomo-webon-kit/src/nomo_platform.ts
+++ b/nomo-webon-kit/src/nomo_platform.ts
@@ -201,9 +201,16 @@ export async function nomoShare(args: {
 /**
  * Closes the current WebOn.
  * Afterwards, it will launch a deeplink if provided.
+ * A launchMode can be specified to control how the deeplink is opened.
  */
 export async function nomoClose(args: {
   deeplink: string | null;
+  launchMode:
+    | null
+    | "platformDefault"
+    | "inAppWebView"
+    | "externalApplication"
+    | "externalNonBrowserApplication";
 }): Promise<void> {
   await invokeNomoFunction("nomoClose", args);
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the application version to "0.2.139" for the "Dev WebOn" application.
	- Enhanced the `nomoClose` function to include a `launchMode` parameter, providing more control over deeplink behavior.

- **Bug Fixes**
	- Modified the `NomoCloseTest` class to accommodate the new `launchMode` parameter in the `nomo.close()` method, improving the closing and reopening functionality of the WebOn instance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->